### PR TITLE
dvbs2rate.c: Fix calculation bit-rate for short FECFRAME

### DIFF
--- a/dvbs2rate.c
+++ b/dvbs2rate.c
@@ -68,7 +68,7 @@ double calc_short(double symbols, double mod, double num, double den, double bch
     double    fec_frame = 16200.0;
     double    tsrate;
 
-    tsrate = symbols / (fec_frame / mod + 90 + ceil((fec_frame/ mod / 90 / 16 - 1)) * pilots) * (fec_frame * (num / den) - (16 * bch) - 80);
+    tsrate = symbols / (fec_frame / mod + 90 + ceil((fec_frame/ mod / 90 / 16 - 1)) * pilots) * (fec_frame * (num / den) - (14 * bch) - 80);
     return (tsrate);
 }
 


### PR DESCRIPTION
Сalculation bit-rate for short FECFRAME seems to be incorrect. According to the ETSI EN 302 307-1, section 5.3.1: 

> A t-error correcting BCH (Nbch , K bch ) code shall be applied to each BBFRAME (Kbch ) to generate an error protected
packet. The BCH code parameters for nldpc = 64 800 are given in table 5a and for n ldpc = 16 200 in table 5b.  
>
>The generator polynomial of the t error correcting BCH encoder is obtained by multiplying the first t polynomials in
table 6a for nldpc = 64 800 and in table 5b for nldpc = 16 200.  

![изображение](https://github.com/user-attachments/assets/ceee4b39-54ed-4cab-bae2-41e31cf097b9)

But here we have `(16 * bch)` for both FECFRAME. As a result it doesn't match the reference values ​​in the standard.

Fix this mistake.